### PR TITLE
dsp.c: remove broken unused include

### DIFF
--- a/src/util/dsp.c
+++ b/src/util/dsp.c
@@ -16,7 +16,6 @@
  */
 #include <string.h>
 #include "dsp.h"
-#include "utils.h"
 
 int aparams_ctltovol[128] = {
 	    0,


### PR DESCRIPTION
The project would not build with it. I could have renamed it to use the proper include but it seemed unused. With this change it builds and everything works as intended, thank you for this nifty project.